### PR TITLE
feat: automatic assigning of sections from subsections

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Initiate a countdown from a Captain or Lead, update the countdown every 5 minute
 
 Download the audit logs every week for the past week, and upload them to Discord to the audit-logs channel (hidden by default). Can also be uploaded manually via command by Captains and Leads.
 
+### Subsection + Section Auto Assignment - Dallas
+
+Assigns the Category role based on a users current role:
+- Dynamics: Frame, Aerodynamics, Brakes, Suspension
+- Electrical: Low Voltage, Embedded, Tractive System
+- Business: Marketing, Purchasing, Sponsorship
+
 ### Deployment - Dallas
 
 This bot is run on the Embedded subsection's shop computer, it's run in a docker container and locally saved files are mounted onto the filesystem to ensure non-volatility.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A Discord bot used internally on our server to provide the following services:
   - [This](https://www.freecodecamp.org/news/create-a-discord-bot-with-javascript-nodejs/) is quite a good guide.
   - Invite the bot to your server with these permissions:
     ![image](https://github.com/GryphonRacingFSAE/Discord-Bot/assets/36043275/20f4ef5f-900d-4ca2-ade2-e2d04a2d7fd6)
+  - This privileged intent is required for auto-role detecting:
+    ![image](https://github.com/GryphonRacingFSAE/Discord-Bot/assets/36043275/5b052e07-70c9-44ab-b98d-9d0ee3149e7e)
 - Populate .env with the required variables:
 
 ```ini

--- a/src/events/member-update.ts
+++ b/src/events/member-update.ts
@@ -1,0 +1,79 @@
+// Detects when a member is updated (i.e roles are added/removed)
+// The purpose of this is to auto-assign Dynamics, Electrical, and Business roles
+
+import { Events, GuildMember } from "discord.js";
+
+function arrayNotUndefined<T>(value: (T | undefined)[]): value is T[] {
+    return value.every(v => v !== undefined);
+}
+
+export async function updateSubsectionRoles(member: GuildMember) {
+    console.log(`Updating subsection roles for ${member.user.tag}`);
+
+    const dynamics = member.guild.roles.cache.find(role => role.name === "Dynamics");
+    const electrical = member.guild.roles.cache.find(role => role.name === "Electrical");
+    const business = member.guild.roles.cache.find(role => role.name === "Business");
+
+    if (!dynamics || !electrical || !business) {
+        console.error("Cannot find one or more of the following roles: Dynamics, Electrical, Business");
+        return;
+    }
+
+    const dynamics_subsections = ["Frame", "Aerodynamics", "Suspension", "Brakes"];
+    const electrical_subsections = ["Low Voltage", "Embedded", "Tractive System"];
+    const business_subsections = ["Purchasing", "Marketing"];
+
+    const dynamics_subsection_roles = dynamics_subsections.map(subsection => member.guild.roles.cache.find(role => role.name === subsection));
+    const electrical_subsection_roles = electrical_subsections.map(subsection => member.guild.roles.cache.find(role => role.name === subsection));
+    const business_subsection_roles = business_subsections.map(subsection => member.guild.roles.cache.find(role => role.name === subsection));
+
+    if (!arrayNotUndefined(dynamics_subsection_roles) || !arrayNotUndefined(electrical_subsection_roles) || !arrayNotUndefined(business_subsection_roles)) {
+        console.error("Cannot find the role for a subsection.");
+        return;
+    }
+
+    // If the member has the Dynamics role
+    if (dynamics_subsection_roles.some(subsection => member.roles.cache.has(subsection.id)) && !member.roles.cache.has(dynamics.id)) {
+        await member.roles.add(dynamics);
+    } else if (!dynamics_subsection_roles.some(subsection => member.roles.cache.has(subsection.id)) && member.roles.cache.has(dynamics.id)) {
+        // If the member has the Dynamics role but no subsection roles
+        await member.roles.remove(dynamics);
+    }
+
+    // If the member has the Electrical role
+    if (electrical_subsection_roles.some(subsection => member.roles.cache.has(subsection.id)) && !member.roles.cache.has(electrical.id)) {
+        await member.roles.add(electrical);
+    } else if (!electrical_subsection_roles.some(subsection => member.roles.cache.has(subsection.id)) && member.roles.cache.has(electrical.id)) {
+        // If the member has the Electrical role but no subsection roles
+        await member.roles.remove(electrical);
+    }
+
+    // If the member has the Business role
+    if (business_subsection_roles.some(subsection => member.roles.cache.has(subsection.id)) && !member.roles.cache.has(business.id)) {
+        await member.roles.add(business);
+    } else if (!business_subsection_roles.some(subsection => member.roles.cache.has(subsection.id)) && member.roles.cache.has(business.id)) {
+        // If the member has the Business role but no subsection roles
+        await member.roles.remove(business);
+    }
+    console.log(`Done updating subsection roles for ${member.user.tag}`);
+}
+
+export default {
+    name: Events.GuildMemberUpdate,
+    once: false,
+    async execute(old_member: GuildMember, new_member: GuildMember) {
+        await updateSubsectionRoles(new_member);
+
+        // If the role(s) are present on the old member object but no longer on the new one (i.e role(s) were removed)
+        const removedRoles = old_member.roles.cache.filter(role => !new_member.roles.cache.has(role.id));
+        if (removedRoles.size > 0) {
+            console.log(`The roles ${removedRoles.map(r => r.name)} were removed from ${old_member.displayName}.`);
+        }
+
+        // If the role(s) are present on the new member object but are not on the old one (i.e role(s) were added)
+        const addedRoles = new_member.roles.cache.filter(role => !old_member.roles.cache.has(role.id));
+        if (addedRoles.size > 0) {
+            console.log(`The roles ${addedRoles.map(r => r.name)} were added to ${old_member.displayName}.`);
+        }
+    },
+};

--- a/src/events/member-update.ts
+++ b/src/events/member-update.ts
@@ -21,7 +21,7 @@ export async function updateSubsectionRoles(member: GuildMember) {
 
     const dynamics_subsections = ["Frame", "Aerodynamics", "Suspension", "Brakes"];
     const electrical_subsections = ["Low Voltage", "Embedded", "Tractive System"];
-    const business_subsections = ["Purchasing", "Marketing"];
+    const business_subsections = ["Purchasing", "Marketing", "Sponsorship"];
 
     const dynamics_subsection_roles = dynamics_subsections.map(subsection => member.guild.roles.cache.find(role => role.name === subsection));
     const electrical_subsection_roles = electrical_subsections.map(subsection => member.guild.roles.cache.find(role => role.name === subsection));

--- a/src/events/member-update.ts
+++ b/src/events/member-update.ts
@@ -48,17 +48,5 @@ export default {
     once: false,
     async execute(old_member: GuildMember, new_member: GuildMember) {
         await updateSubsectionRoles(new_member);
-
-        // If the role(s) are present on the old member object but no longer on the new one (i.e role(s) were removed)
-        const removedRoles = old_member.roles.cache.filter(role => !new_member.roles.cache.has(role.id));
-        if (removedRoles.size > 0) {
-            console.log(`The roles ${removedRoles.map(r => r.name)} were removed from ${old_member.displayName}.`);
-        }
-
-        // If the role(s) are present on the new member object but are not on the old one (i.e role(s) were added)
-        const addedRoles = new_member.roles.cache.filter(role => !old_member.roles.cache.has(role.id));
-        if (addedRoles.size > 0) {
-            console.log(`The roles ${addedRoles.map(r => r.name)} were added to ${old_member.displayName}.`);
-        }
     },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ dotenv.config();
 // Some hack to get __dirname to work in modules
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const client = new DiscordClient({ intents: [GatewayIntentBits.Guilds] });
+const client = new DiscordClient({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMembers] });
 
 // Load in commands
 {
@@ -47,6 +47,7 @@ const client = new DiscordClient({ intents: [GatewayIntentBits.Guilds] });
         } else {
             client.on(event.name, (...args) => event.execute(...args));
         }
+        console.log(`Loaded event ${event.name}`);
     }
 }
 


### PR DESCRIPTION
# Category assignment from sub-sections

Auto assign categories (Business, Electrical, Dynamics) based on the user's current subsections

## Changes

- Added autoassignment of categories for sub-sections

## Deployment

- Renamed ready.mts to ready.ts as I missed that earlier, as the bot wasn't pulling that event in on startup

## Proof of functionality (screenshot, logs, etc)

![image](https://github.com/GryphonRacingFSAE/Discord-Bot/assets/36043275/8e2fd90f-c2fa-404d-90cd-b12cd5d2f300)

## Checklist

- [x] Your code builds clean without any errors or warnings
- [x] Code has been formatted (clang-format, cmake-format, black, prettier, rustfmt, etc)
- [N/A] Where possible, unit tests have been added
- [x] Code is well-commented & understood
