### PR TITLE
Fix countdown command referencing the wrong file

### DIFF
--- a/src/countdown-manager.ts
+++ b/src/countdown-manager.ts
@@ -29,8 +29,7 @@ type Countdowns = {
 };
 
 // Deserialize messages
-const message_dictionary: Countdowns = fs.existsSync("./messages.json")
-    ? JSON.parse(fs.readFileSync("./resources/messages.json", "utf8"), (key, value) => {
+const message_dictionary: Countdowns = JSON.parse(fs.readFileSync("./resources/messages.json", "utf8"), (key, value) => {
           if (key === "event_date") {
               return new Date(value);
           }

--- a/src/countdown-manager.ts
+++ b/src/countdown-manager.ts
@@ -34,8 +34,7 @@ const message_dictionary: Countdowns = JSON.parse(fs.readFileSync("./resources/m
               return new Date(value);
           }
           return value;
-      })
-    : {};
+      });
 
 // Function to write current message dictionary info to file
 function updateMessageDictionary() {

--- a/src/countdown-manager.ts
+++ b/src/countdown-manager.ts
@@ -29,12 +29,14 @@ type Countdowns = {
 };
 
 // Deserialize messages
-const message_dictionary: Countdowns = JSON.parse(fs.readFileSync("./resources/messages.json", "utf8"), (key, value) => {
-    if (key === "event_date") {
-        return new Date(value);
-    }
-    return value;
-});
+const message_dictionary: Countdowns = fs.existsSync("./resources/messages.json")
+    ? JSON.parse(fs.readFileSync("./resources/messages.json", "utf8"), (key, value) => {
+          if (key === "event_date") {
+              return new Date(value);
+          }
+          return value;
+      })
+    : {};
 
 // Function to write current message dictionary info to file
 function updateMessageDictionary() {

--- a/src/countdown-manager.ts
+++ b/src/countdown-manager.ts
@@ -30,11 +30,11 @@ type Countdowns = {
 
 // Deserialize messages
 const message_dictionary: Countdowns = JSON.parse(fs.readFileSync("./resources/messages.json", "utf8"), (key, value) => {
-          if (key === "event_date") {
-              return new Date(value);
-          }
-          return value;
-      });
+    if (key === "event_date") {
+        return new Date(value);
+    }
+    return value;
+});
 
 // Function to write current message dictionary info to file
 function updateMessageDictionary() {


### PR DESCRIPTION
# TASK TITLE

Countdown may refer to the wrong file and thus get confused which countdowns are where

## Changes

- Use resource/messages.json
- **This does introduce a breaking change and all ./messages.json should be deleted/moved to ./resources/messages.json**
