### PR TITLE
evan/message-scan-fix

### DIFF
--- a/src/door-status.ts
+++ b/src/door-status.ts
@@ -81,7 +81,8 @@ export async function initDoorStatus(client: Client) {
 async function sendDoorStatusMessage(channel: TextChannel, door_status: boolean | null) {
     try {
         // Fetch and delete all previous bot messages in the channel
-        await channel.messages.fetch();
+        const limit = 50;
+        await channel.messages.fetch({ limit });
         const messages_to_delete = channel.messages.cache.filter(message => message.author.bot);
         await channel.bulkDelete(messages_to_delete);
 

--- a/src/door-status.ts
+++ b/src/door-status.ts
@@ -81,8 +81,7 @@ export async function initDoorStatus(client: Client) {
 async function sendDoorStatusMessage(channel: TextChannel, door_status: boolean | null) {
     try {
         // Fetch and delete all previous bot messages in the channel
-        const limit = 50;
-        await channel.messages.fetch({ limit });
+        await channel.messages.fetch({ limit: 50 });
         const messages_to_delete = channel.messages.cache.filter(message => message.author.bot);
         await channel.bulkDelete(messages_to_delete);
 


### PR DESCRIPTION
Reduces messages the bot has to scan when replacing the door status message:
Entire channel history --> 50 messages max