### PR TITLE
fix: actually clear out queue after we're done iterating through it

### DIFF
--- a/src/vertification.ts
+++ b/src/vertification.ts
@@ -113,9 +113,13 @@ async function pushSpreadsheet() {
         pullSpreadsheet(); // Make sure we get an updated spreadsheet
 
         // Best way I could get it to only append
-        verification_spreadsheet_queue.forEach(change => {
+        while (verification_spreadsheet_queue.length) {
+            const change = verification_spreadsheet_queue.pop();
+            if (!change) {
+                break;
+            }
             verification_spreadsheet[change.index] = change.row;
-        });
+        }
 
         const workbook = utils.book_new();
         const translated_spreadsheet = verification_spreadsheet.map((row: Verification) => {


### PR DESCRIPTION
Forgot to clear out the queue every time we fulfill a request. This _should_ pop the queue and fulfill each request every time it does so. Please check if this actually does what it does as I'm not entirely sure this is correct usage.