### PR TITLE
Danny/excess pulling

### DIFF
--- a/src/vertification.ts
+++ b/src/vertification.ts
@@ -376,6 +376,7 @@ export async function handleVerification(client: Client, message: Message) {
             id: verification_code,
             time_stamp: Date.now(),
         });
+        console.log("Attempting to send an email to:", user_row);
         await transporter
             .sendMail({
                 from: process.env.EMAIL_USERNAME,

--- a/src/vertification.ts
+++ b/src/vertification.ts
@@ -312,7 +312,7 @@ function validateMembership(user_row: Verification): boolean {
     if (current_month >= 4 && current_month <= 8) {
         return true;
     }
-    return user_row.payment_status === PAYMENT_ACCEPT && user_row.in_gryphlife === GRYPHLIFE_ACCEPT;
+    return user_row.payment_status.trim().toLowerCase() === PAYMENT_ACCEPT.trim().toLowerCase() && user_row.in_gryphlife.trim().toLowerCase() === GRYPHLIFE_ACCEPT.trim().toLowerCase();
 }
 
 // This handles the process of sending a verification message out to the user, but not processing if the code.
@@ -391,10 +391,10 @@ export async function handleVerification(client: Client, message: Message) {
             });
         await message.reply({ content: "Please **DM the bot** with a 7 digit code sent to the email address. Type `cancel` if you wish to cancel the verification code." });
         return;
-    }
-
-    if (user_row.payment_status.trim() !== PAYMENT_ACCEPT) {
+    } else if (user_row.payment_status.trim().toLowerCase() !== PAYMENT_ACCEPT.trim().toLowerCase()) {
         await message.reply({ content: "You may have not paid your team fee yet, this must be manually reviewed, please be patient." });
+    } else if (user_row.in_gryphlife.trim().toLowerCase() !== GRYPHLIFE_ACCEPT.trim().toLowerCase()) {
+        await message.reply({ content: "You may have not joined GrpyhLife yet, this must be manually reviewed, please be patient." });
     }
 }
 

--- a/src/vertification.ts
+++ b/src/vertification.ts
@@ -244,10 +244,6 @@ export async function verificationOnReady(client: Client) {
 
     // Update spreadsheet
     await pullSpreadsheet();
-    fs.watch(FILE_PATH, () => {
-        console.log("Changes made! Pulling spreadsheet");
-        pullSpreadsheet();
-    });
 
     const verified_role = guild.roles.cache.find(role => role.name === "Verified");
     if (!verified_role) {


### PR DESCRIPTION
- Fix excess pulling as on every push, we already pull and due to the queue system ensuring that we only append information and never override, pulling every time the file is updated is excessive and may be the root cause of many syncing issues (locking)
- Improve error messages as some users do not receive messages as to why they've received no response from the bot
- Broaden membership validation to not care for whitespaces before and after of "In GryphLife" + "Has Paid" and not be case-sensitive. This should hopefully resolve some errors have experienced